### PR TITLE
Changed sync identifier field from id to username

### DIFF
--- a/login_backend/middleware.py
+++ b/login_backend/middleware.py
@@ -4,6 +4,9 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
 
+import logging
+logger = logging.getLogger("login_backend")
+
 from .utils import get_login_user
 
 try:
@@ -14,10 +17,13 @@ except ImportError:
 
 class LoginServiceAuthenticationMiddleware(MiddlewareMixin):
     def process_request(self, request):
+        logging.debug(f"Processing login service authentication, request: {request}")
         assert hasattr(request, 'session'), (
             "The authentication middleware requires session middleware "
             "to be installed. Edit your MIDDLEWARE%s setting to insert "
             "'django.contrib.sessions.middleware.SessionMiddleware' before "
             "'%s'."
         ) % ("_CLASSES" if settings.MIDDLEWARE is None else '', type(self))
-        request.user = SimpleLazyObject(lambda: get_login_user(request.session.get('_user')))
+        logging.debug(f"Getting _user from request.session: {request.session}")
+        user = request.session.get('_user')
+        request.user = SimpleLazyObject(lambda: get_login_user(user))

--- a/login_backend/middleware.py
+++ b/login_backend/middleware.py
@@ -17,13 +17,12 @@ except ImportError:
 
 class LoginServiceAuthenticationMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        logging.debug(f"Processing login service authentication, request: {request}")
+        logger.debug("Processing login service authentication")
         assert hasattr(request, 'session'), (
             "The authentication middleware requires session middleware "
             "to be installed. Edit your MIDDLEWARE%s setting to insert "
             "'django.contrib.sessions.middleware.SessionMiddleware' before "
             "'%s'."
         ) % ("_CLASSES" if settings.MIDDLEWARE is None else '', type(self))
-        logging.debug(f"Getting _user from request.session: {request.session}")
         user = request.session.get('_user')
         request.user = SimpleLazyObject(lambda: get_login_user(user))

--- a/login_backend/sessions.py
+++ b/login_backend/sessions.py
@@ -5,6 +5,9 @@ import requests
 from django.conf import settings
 from django.contrib.sessions.backends.base import CreateError, SessionBase
 
+import logging
+logger = logging.getLogger("login_backend")
+
 try:
     from django.contrib.sessions.backends.base import UpdateError
 except ImportError:
@@ -14,9 +17,12 @@ except ImportError:
 
 class SessionStore(SessionBase):
     def load(self):
+        logging.debug(f"Loading session with key: {self.session_key}")
         session_data = self._request(requests.get, self.get_endpoint(self.session_key))
         if session_data is not None:
+            logging.debug(f"Session data found: {session_data}")
             return session_data
+        logging.debug("Session data not found.")
         self._session_key = None
         return {}
 
@@ -33,7 +39,9 @@ class SessionStore(SessionBase):
             endpoint = self.get_endpoint(self.session_key)
             error = UpdateError
         session_data = self._request(method, endpoint, data=self._get_session(no_load=True))
+        logging.debug(f"Session data retrieved: {session_data}")
         if session_data is None:
+            logging.error("Session data is empty.")
             raise error
 
         self._session_key = session_data['_session_key']
@@ -47,8 +55,10 @@ class SessionStore(SessionBase):
     def delete(self, session_key=None):
         if session_key is None:
             if self.session_key is None:
+                logging.debug("Attempting to delete session, no session key found.")
                 return
             session_key = self.session_key
+        logging.debug(f"Deleting session, session_key: {session_key}")
         self._request(requests.delete, self.get_endpoint(session_key))
 
     @classmethod
@@ -69,18 +79,23 @@ class SessionStore(SessionBase):
             headers = dict()
         token = getattr(settings, 'LOGIN_SERVICE_TOKEN', None)
         if token:
+            logging.debug("Creating authorization header with token: {token}")
             headers['Authorization'] = 'Token {}'.format(token)
         return headers
 
     def _request(self, method, url, data=None, headers=None):
+        logging.debug("Requesting session data")
         headers = self.get_headers(headers)
         resp = method(url, data=data, headers=headers)
         session_data = None
+        logging.debug(f"Session request data, url: {url}\nheaders:\n{headers}\ndata:\n{data}")
         try:
             resp.raise_for_status()
-        except requests.HTTPError:
-            pass
+        except requests.HTTPError as e:
+            err_message = str(e)
+            logging.error(f"HTTP error occurred: {err_message}")
         else:
             if resp.content:
                 session_data = resp.json()
+        logging.debug(f"Session data retrieved:\n{session_data}")
         return session_data

--- a/login_backend/sessions.py
+++ b/login_backend/sessions.py
@@ -17,12 +17,9 @@ except ImportError:
 
 class SessionStore(SessionBase):
     def load(self):
-        logging.debug(f"Loading session with key: {self.session_key}")
         session_data = self._request(requests.get, self.get_endpoint(self.session_key))
         if session_data is not None:
-            logging.debug(f"Session data found: {session_data}")
             return session_data
-        logging.debug("Session data not found.")
         self._session_key = None
         return {}
 
@@ -39,9 +36,8 @@ class SessionStore(SessionBase):
             endpoint = self.get_endpoint(self.session_key)
             error = UpdateError
         session_data = self._request(method, endpoint, data=self._get_session(no_load=True))
-        logging.debug(f"Session data retrieved: {session_data}")
         if session_data is None:
-            logging.error("Session data is empty.")
+            logger.error("Session data is empty.")
             raise error
 
         self._session_key = session_data['_session_key']
@@ -55,10 +51,8 @@ class SessionStore(SessionBase):
     def delete(self, session_key=None):
         if session_key is None:
             if self.session_key is None:
-                logging.debug("Attempting to delete session, no session key found.")
                 return
             session_key = self.session_key
-        logging.debug(f"Deleting session, session_key: {session_key}")
         self._request(requests.delete, self.get_endpoint(session_key))
 
     @classmethod
@@ -79,23 +73,20 @@ class SessionStore(SessionBase):
             headers = dict()
         token = getattr(settings, 'LOGIN_SERVICE_TOKEN', None)
         if token:
-            logging.debug("Creating authorization header with token: {token}")
             headers['Authorization'] = 'Token {}'.format(token)
         return headers
 
     def _request(self, method, url, data=None, headers=None):
-        logging.debug("Requesting session data")
+        logger.debug("Requesting session data")
         headers = self.get_headers(headers)
         resp = method(url, data=data, headers=headers)
         session_data = None
-        logging.debug(f"Session request data, url: {url}\nheaders:\n{headers}\ndata:\n{data}")
         try:
             resp.raise_for_status()
         except requests.HTTPError as e:
             err_message = str(e)
-            logging.error(f"HTTP error occurred: {err_message}")
+            logger.error(f"HTTP error occurred: {err_message}")
         else:
             if resp.content:
                 session_data = resp.json()
-        logging.debug(f"Session data retrieved:\n{session_data}")
         return session_data

--- a/login_backend/user.py
+++ b/login_backend/user.py
@@ -80,6 +80,8 @@ class SyncingLoginUser(LoginUser):
         """
         Creates/updates a corresponding local auth.User object during __init__
         """
+        self._django_user_cache = None
+
         # Missing Groups needs to exist before calling super.__init__
         groups = []
         for group_name in user_data.get("groups", []):

--- a/login_backend/user.py
+++ b/login_backend/user.py
@@ -80,7 +80,7 @@ class SyncingLoginUser(LoginUser):
 
         super(SyncingLoginUser, self).__init__(user_data)
         local_user, _ = User.objects.update_or_create(
-            id=self.pk,
+            username=self.username,
             defaults={
                 "username": self.username,
                 "email": self.email,

--- a/login_backend/user.py
+++ b/login_backend/user.py
@@ -75,6 +75,7 @@ class LoginUser(object):
         return getattr(self, 'first_name', '')
 
 
+
 class SyncingLoginUser(LoginUser):
     def __init__(self, user_data):
         """
@@ -151,3 +152,33 @@ class SyncingLoginUser(LoginUser):
     def pk(self, value: int) -> None:
         """Prevent setting pk - it's read-only from synced Django User."""
         pass
+
+
+class SyncingLoginUserWithId(LoginUser):
+    def __init__(self, user_data):
+        """
+        Creates/updates a corresponding local auth.User object during __init__
+        This class sets the id explicitly based on the id from login service.
+        """
+        # Missing Groups needs to exist before calling super.__init__
+        groups = []
+        for group_name in user_data.get("groups", []):
+            groups.append(Group.objects.get_or_create(name=group_name)[0])
+
+        super(SyncingLoginUser, self).__init__(user_data)
+        local_user, _ = User.objects.update_or_create(
+            id=self.pk,
+            defaults={
+                "username": self.username,
+                "email": self.email,
+                "first_name": self.first_name,
+                "last_name": self.last_name,
+                "is_staff": self.is_staff,
+                "is_active": self.is_active,
+                "is_superuser": self.is_superuser,
+                "last_login": timezone.now(),
+            },
+        )
+
+        local_user.groups.set(groups)
+

--- a/login_backend/user.py
+++ b/login_backend/user.py
@@ -60,9 +60,6 @@ class LoginUser(object):
     def get_username(self):
         return getattr(self, 'username', '')
 
-    def get_id(self):
-        return getattr(self, 'id', None)
-
     def get_full_name(self):
         """
         Return the first_name plus the last_name, with a space in between.
@@ -75,13 +72,14 @@ class LoginUser(object):
         return getattr(self, 'first_name', '')
 
 
-
 class SyncingLoginUser(LoginUser):
+    
+    _cached_django_user = None
+
     def __init__(self, user_data):
         """
         Creates/updates a corresponding local auth.User object during __init__
         """
-        self._django_user_cache = None
 
         # Missing Groups needs to exist before calling super.__init__
         groups = []
@@ -92,7 +90,6 @@ class SyncingLoginUser(LoginUser):
         local_user, _ = User.objects.update_or_create(
             username=self.username,
             defaults={
-                "username": self.username,
                 "email": self.email,
                 "first_name": self.first_name,
                 "last_name": self.last_name,
@@ -106,23 +103,24 @@ class SyncingLoginUser(LoginUser):
         local_user.groups.set(groups)
 
         # cache the local user
-        self._django_user_cache = local_user
+        self._cached_django_user = local_user
 
     def _load_django_user(self) -> None:
         """Load the synced Django user into cache."""
-        if self._django_user_cache is None and self.username:
+        if self._cached_django_user is None and self.username:
             try:
-                self._django_user_cache = User.objects.get(username=self.username)
+                self._cached_django_user = User.objects.get(username=self.username)
             except User.DoesNotExist:
                 logger.error(f"Django User not found for username: {self.username}")
-                self._django_user_cache = None
+                self._cached_django_user = None
+                raise
 
     @property
     def django_user(self) -> Optional[User]:
         """Return the synced Django auth.User if available."""
-        if self._django_user_cache is None:
+        if self._cached_django_user is None:
             self._load_django_user()
-        return self._django_user_cache
+        return self._cached_django_user
 
     @property
     def id(self) -> Optional[int]:
@@ -165,7 +163,7 @@ class SyncingLoginUserWithId(LoginUser):
         for group_name in user_data.get("groups", []):
             groups.append(Group.objects.get_or_create(name=group_name)[0])
 
-        super(SyncingLoginUser, self).__init__(user_data)
+        super(SyncingLoginUserWithId, self).__init__(user_data)
         local_user, _ = User.objects.update_or_create(
             id=self.pk,
             defaults={

--- a/login_backend/user.py
+++ b/login_backend/user.py
@@ -5,14 +5,18 @@ import django
 from django.utils import timezone
 from django.contrib.auth.models import User, Group
 
+import logging
+logger = logging.getLogger("login_backend")
 
 class LoginUser(object):
     def __init__(self, user_data):
+        logging.debug(f"Instantiating user with: {user_data}")
         self.groups = Group.objects.filter(name__in=user_data.pop('groups', []))
         for key, value in user_data.items():
             setattr(self, key, value)
 
     def get_group_permissions(self, obj=None):
+        logging.debug(f"Getting group permissions: {obj}")
         if not hasattr(self, '_group_permissions'):
             self._group_permissions = set(
                 '{}.{}'.format(app, codename)
@@ -73,6 +77,7 @@ class SyncingLoginUser(LoginUser):
         """
         Creates/updates a corresponding local auth.User object during __init__
         """
+        logging.debug(f"Creating or updating user with data: {user_data}")
         # Missing Groups needs to exist before calling super.__init__
         groups = []
         for group_name in user_data.get("groups", []):

--- a/login_backend/user.py
+++ b/login_backend/user.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import django
-from typing import Any
+from typing import Any, Optional
 from django.utils import timezone
 from django.contrib.auth.models import User, Group
 
@@ -101,7 +101,7 @@ class SyncingLoginUser(LoginUser):
         )
 
         local_user.groups.set(groups)
-        
+
         # cache the local user
         self._django_user_cache = local_user
 
@@ -115,14 +115,14 @@ class SyncingLoginUser(LoginUser):
                 self._django_user_cache = None
 
     @property
-    def django_user(self) -> User:
+    def django_user(self) -> Optional[User]:
         """Return the synced Django auth.User if available."""
         if self._django_user_cache is None:
             self._load_django_user()
         return self._django_user_cache
 
     @property
-    def id(self) -> int | Any:
+    def id(self) -> Optional[int]:
         """
         Return ONLY the ID of the synced Django user for admin compatibility.
         Never returns the login service user ID.
@@ -138,7 +138,7 @@ class SyncingLoginUser(LoginUser):
         pass
 
     @property
-    def pk(self) -> int | Any:
+    def pk(self) -> Optional[int]:
         """
         Alias for id to ensure Django admin compatibility.
         Never returns the login service user ID.

--- a/login_backend/user.py
+++ b/login_backend/user.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import django
+from typing import Any
 from django.utils import timezone
 from django.contrib.auth.models import User, Group
 
@@ -60,6 +61,9 @@ class LoginUser(object):
     def get_username(self):
         return getattr(self, 'username', '')
 
+    def get_id(self):
+        return getattr(self, 'id', None)
+
     def get_full_name(self):
         """
         Return the first_name plus the last_name, with a space in between.
@@ -99,3 +103,51 @@ class SyncingLoginUser(LoginUser):
         )
 
         local_user.groups.set(groups)
+        
+        # cache the local user
+        self._django_user_cache = local_user
+
+    def _load_django_user(self) -> None:
+        """Load the synced Django user into cache."""
+        if self._django_user_cache is None and self.username:
+            try:
+                self._django_user_cache = User.objects.get(username=self.username)
+            except User.DoesNotExist:
+                logger.error(f"Django User not found for username: {self.username}")
+                self._django_user_cache = None
+
+    @property
+    def django_user(self) -> User:
+        """Return the synced Django auth.User if available."""
+        if self._django_user_cache is None:
+            self._load_django_user()
+        return self._django_user_cache
+
+    @property
+    def id(self) -> int | Any:
+        """
+        Return ONLY the ID of the synced Django user for admin compatibility.
+        Never returns the login service user ID.
+        """
+        django_user = self.django_user
+        if django_user:
+            return django_user.id
+        return None
+
+    @id.setter
+    def id(self, value: int) -> None:
+        """Prevent setting id - it's read-only from synced Django User."""
+        pass
+
+    @property
+    def pk(self) -> int | Any:
+        """
+        Alias for id to ensure Django admin compatibility.
+        Never returns the login service user ID.
+        """
+        return self.id
+
+    @pk.setter
+    def pk(self, value: int) -> None:
+        """Prevent setting pk - it's read-only from synced Django User."""
+        pass

--- a/login_backend/user.py
+++ b/login_backend/user.py
@@ -11,13 +11,12 @@ logger = logging.getLogger("login_backend")
 
 class LoginUser(object):
     def __init__(self, user_data):
-        logging.debug(f"Instantiating user with: {user_data}")
         self.groups = Group.objects.filter(name__in=user_data.pop('groups', []))
         for key, value in user_data.items():
             setattr(self, key, value)
 
     def get_group_permissions(self, obj=None):
-        logging.debug(f"Getting group permissions: {obj}")
+        logger.debug(f"Getting group permissions: {obj}")
         if not hasattr(self, '_group_permissions'):
             self._group_permissions = set(
                 '{}.{}'.format(app, codename)
@@ -81,7 +80,6 @@ class SyncingLoginUser(LoginUser):
         """
         Creates/updates a corresponding local auth.User object during __init__
         """
-        logging.debug(f"Creating or updating user with data: {user_data}")
         # Missing Groups needs to exist before calling super.__init__
         groups = []
         for group_name in user_data.get("groups", []):

--- a/login_backend/utils.py
+++ b/login_backend/utils.py
@@ -19,7 +19,6 @@ def get_login_user(user_data):
     if user_data:
         UserClass = import_string(getattr(
             settings, 'LOGIN_SERVICE_USER_CLASS', 'login_backend.user.LoginUser'))
-        logger.debug(f"Instantiating user with class: {UserClass}")
         user = UserClass(user_data)
         logger.debug(f"Created user: {user}")
         return user

--- a/login_backend/utils.py
+++ b/login_backend/utils.py
@@ -4,6 +4,9 @@ from __future__ import unicode_literals
 from django.contrib.auth.models import AnonymousUser
 from django.conf import settings
 
+import logging
+logger = logging.getLogger("login_backend")
+
 try:
     from django.utils.module_loading import import_string
 except ImportError:
@@ -12,9 +15,13 @@ except ImportError:
 
 
 def get_login_user(user_data):
+    logging.debug(f"Getting login user: {user_data}")
     if user_data:
         UserClass = import_string(getattr(
             settings, 'LOGIN_SERVICE_USER_CLASS', 'login_backend.user.LoginUser'))
+        logging.debug(f"Instantiating user with class: {UserClass}")
         user = UserClass(user_data)
+        logging.debug(f"Created user: {user}")
         return user
+    logging.debug("No user data found, returning AnonymousUser.")
     return AnonymousUser()

--- a/login_backend/utils.py
+++ b/login_backend/utils.py
@@ -15,13 +15,13 @@ except ImportError:
 
 
 def get_login_user(user_data):
-    logging.debug(f"Getting login user: {user_data}")
+    logger.debug(f"Getting login user: {user_data}")
     if user_data:
         UserClass = import_string(getattr(
             settings, 'LOGIN_SERVICE_USER_CLASS', 'login_backend.user.LoginUser'))
-        logging.debug(f"Instantiating user with class: {UserClass}")
+        logger.debug(f"Instantiating user with class: {UserClass}")
         user = UserClass(user_data)
-        logging.debug(f"Created user: {user}")
+        logger.debug(f"Created user: {user}")
         return user
-    logging.debug("No user data found, returning AnonymousUser.")
+    logger.debug("No user data found, returning AnonymousUser.")
     return AnonymousUser()


### PR DESCRIPTION
This allows for existing users in non-SSO apps to keep all the existing foreign references while only needing to update the username to their Halliburton SSO username. 